### PR TITLE
add support for defining cmd on a per-project level

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ To install via Package Control, do the following:
 ## Settings
 For general information on how SublimeLinter works with settings, please see [Settings](http://sublimelinter.readthedocs.org/en/latest/settings.html). For information on generic linter settings, please see [Linter Settings](http://sublimelinter.readthedocs.org/en/latest/linter_settings.html).
 
+### Project Specific Executable
+It is possible to specify the `phpcs` executable that should be used to lint your code on a per-project level.
+
+**Example:**
+```json
+{
+    "SublimeLinter": {
+        "linters": {
+            "phpcs": {
+                "cmd": "${project}/vendor/bin/phpcs"
+            }
+        }
+    }
+}
+```
+
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:
 

--- a/linter.py
+++ b/linter.py
@@ -24,9 +24,21 @@ class Phpcs(Linter):
         r'message="(?P<message>.*)" source'
     )
     executable = 'phpcs'
-    cmd = 'phpcs --report=checkstyle'
     defaults = {
         '--standard=': 'PSR2',
     }
     inline_overrides = ('standard')
     tempfile_suffix = 'php'
+
+    def cmd(self):
+        """Read cmd from inline settings."""
+        settings = Linter.get_view_settings(self)
+
+        if 'cmd' in settings:
+            command = [settings.get('cmd')]
+        else:
+            command = [self.executable_path]
+
+        command.append('--report=checkstyle')
+
+        return command

--- a/messages.json
+++ b/messages.json
@@ -1,3 +1,4 @@
 {
-    "install": "messages/install.txt"
+    "install": "messages/install.txt",
+    "1.1.0": "messages/1.1.0.txt"
 }

--- a/messages/1.1.0.txt
+++ b/messages/1.1.0.txt
@@ -1,0 +1,15 @@
+SublimeLinter-phpcs 1.1.0
+---------------------------
+
+This version adds support for declaring per-project linter executable files.
+
+Example (*.sublime-project):
+{
+    "SublimeLinter": {
+        "linters": {
+            "phpcs": {
+                "cmd": "${project}/vendor/bin/phpcs"
+            }
+        }
+    }
+}


### PR DESCRIPTION
* implements a custom `cmd()` method to check for the existence
  of an inline `cmd` setting
* updated README documentation to show example of new functionality

closes #10