### PR TITLE
Switch back to STREAM_BOTH

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -1,4 +1,4 @@
-from SublimeLinter.lint import ComposerLinter, util
+from SublimeLinter.lint import ComposerLinter
 
 
 class Phpcs(ComposerLinter):
@@ -11,4 +11,3 @@ class Phpcs(ComposerLinter):
         '--stdin-path=': '${file}',
         '--standard=': 'PSR2',
     }
-    error_stream = util.STREAM_STDOUT


### PR DESCRIPTION
Partially tackles #33

Switching to STREAM_BOTH means SL can handle stderr output automatically (SL version >4.3 required).