### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can set up your project settings to use a specific standard using the follow
     "SublimeLinter": {
         "linters": {
             "phpcs": {
-                "standard": "${folder}/phpcs.xml"
+                "args": "--standard=${folder}/phpcs.xml"
             }
         }
     }


### PR DESCRIPTION
`readme.md` says to change the standard via `linters.phpcs.standard` when it should be done by args.

It'll probably save a few minutes to people who missed reading the plugin update message and are wondering why all their files are suddenly full of red underlines and squares.