### PR TITLE
Include error and sniff code in error message

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -1,9 +1,8 @@
 from SublimeLinter.lint import ComposerLinter
 
-
 class Phpcs(ComposerLinter):
-    cmd = ('phpcs', '--report=emacs', '${args}', '-')
-    regex = r'^.*:(?P<line>[0-9]+):(?P<col>[0-9]+): (?:(?P<error>error)|(?P<warning>warning)) - (?P<message>.+)'
+    cmd = ('phpcs', '--report=csv', '${args}', '-')
+    regex = r'^(?!File).*",(?P<line>[0-9]+),(?P<col>[0-9]+),(?:(?P<error>error)|(?P<warning>warning)),(?P<message>".+",.+),[0-9],[01]'
     composer_name = 'phpcs'
     defaults = {
         'selector': 'source.php - text.blade, text.html.basic',


### PR DESCRIPTION
I did this to open up the ability for me to filter out fixable errors with `[01]` -> `0`.

This specific PR just does the initial step of replacing the emacs report with csv report which reports the sniff namespace/code as well.

e.g:
```
SublimeLinter: #35 linter.py:955: phpcs output:
    File,Line,Column,Type,Message,Source,Severity,Fixable
    "~/test.php",4,21,error,"Opening brace of a class must be on the line after the definition",PSR2.Classes.ClassDeclaration.OpenBraceNewLine,5,1
SublimeLinter: #35 linter.py:995: phpcs: No match for line: 'File,Line,Column,Type,Message,Source,Severity,Fixable'
```

Would report: 

```
"Opening brace of a class must be on the line after the definition",PSR2.Classes.ClassDeclaration.OpenBraceNewLine
```

This is useful when you want to run your own less noisey ruleset on a legacy codebase and need the sniff rule names frequently.

**Note:**
Not super well tested yet - you may want to check the regex properly catches csv / quote nesting.