### PR TITLE
add -s flag to include error code

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ Before using this plugin, ensure that `phpcs` is installed on your system, prefe
 - SublimeLinter settings: http://sublimelinter.com/en/latest/settings.html
 - Linter settings: http://sublimelinter.com/en/latest/linter_settings.html
 
+Use the `"args"` setting to configure the coding standard, and/or to display the sniff codes for each error:
+
+```json
+{
+    "args": [
+        "--standard=PEAR", // code standard
+        "-s"               // display sniff codes
+    ]
+}
+```
+
 ### Per-project Standards
 You can set up your project settings to use a specific standard using the following: 
 

--- a/linter.py
+++ b/linter.py
@@ -2,8 +2,8 @@ from SublimeLinter.lint import ComposerLinter
 
 
 class Phpcs(ComposerLinter):
-    cmd = ('phpcs', '--report=emacs', '${args}', '-')
-    regex = r'^.*:(?P<line>[0-9]+):(?P<col>[0-9]+): (?:(?P<error>error)|(?P<warning>warning)) - (?P<message>.+)'
+    cmd = ('phpcs', '-s', '--report=emacs', '${args}', '-')
+    regex = r'^.*:(?P<line>[0-9]+):(?P<col>[0-9]+): (?:(?P<error>error)|(?P<warning>warning)) - (?P<message>.+) \((?P<code>.*)\)'
     defaults = {
         'selector': 'source.php - text.blade, text.html.basic',
         # we want auto-substitution of the filename, but `cmd` does not support that yet

--- a/linter.py
+++ b/linter.py
@@ -2,8 +2,8 @@ from SublimeLinter.lint import ComposerLinter
 
 
 class Phpcs(ComposerLinter):
-    cmd = ('phpcs', '-s', '--report=emacs', '${args}', '-')
-    regex = r'^.*:(?P<line>[0-9]+):(?P<col>[0-9]+): (?:(?P<error>error)|(?P<warning>warning)) - (?P<message>.+) \((?P<code>.*)\)'  # noqa: E501
+    cmd = ('phpcs', '--report=emacs', '${args}', '-')
+    regex = r'^.*:(?P<line>[0-9]+):(?P<col>[0-9]+): (?:(?P<error>error)|(?P<warning>warning)) - (?P<message>(.(?!\(\S+\)$))+)( \((?P<code>\S+)\)$)?'  # noqa: E501
     defaults = {
         'selector': 'source.php - text.blade, text.html.basic',
         # we want auto-substitution of the filename,

--- a/linter.py
+++ b/linter.py
@@ -3,9 +3,10 @@ from SublimeLinter.lint import ComposerLinter
 
 class Phpcs(ComposerLinter):
     cmd = ('phpcs', '-s', '--report=emacs', '${args}', '-')
-    regex = r'^.*:(?P<line>[0-9]+):(?P<col>[0-9]+): (?:(?P<error>error)|(?P<warning>warning)) - (?P<message>.+) \((?P<code>.*)\)'
+    regex = r'^.*:(?P<line>[0-9]+):(?P<col>[0-9]+): (?:(?P<error>error)|(?P<warning>warning)) - (?P<message>.+) \((?P<code>.*)\)'  # noqa: E501
     defaults = {
         'selector': 'source.php - text.blade, text.html.basic',
-        # we want auto-substitution of the filename, but `cmd` does not support that yet
+        # we want auto-substitution of the filename,
+        # but `cmd` does not support that yet
         '--stdin-path=': '${file}'
     }


### PR DESCRIPTION
Granted, the error codes are a bit long...

<img width="644" alt="Screen Shot 2020-06-06 at 22 51 26" src="https://user-images.githubusercontent.com/2543659/83954298-48294f80-a848-11ea-9ef6-1f3372bb2878.png">
