### PR TITLE
fix #54 misplaced highlights with tab indents

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,11 @@ Before using this plugin, ensure that `phpcs` is installed on your system, prefe
 
 Use the `"args"` setting to configure the coding standard, if you've not done so via [configuration file](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset). 
 
-The `--tab-width`, setting controls whether phpcs converts tabs to spaces automatically based on the view (default: `true`), or specifically (e.g. `4`), or not at all (`false`).
-
 ```json
 {
     "args": [
         "--standard=PEAR", // code standard
     ]
-    "--tab-width": true/false/a number
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,14 @@ Before using this plugin, ensure that `phpcs` is installed on your system, prefe
 
 Use the `"args"` setting to configure the coding standard, if you've not done so via [configuration file](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Annotated-Ruleset). 
 
+The `--tab-width`, setting controls whether phpcs converts tabs to spaces automatically based on the view (default: `true`), or specifically (e.g. `4`), or not at all (`false`).
+
 ```json
 {
     "args": [
         "--standard=PEAR", // code standard
     ]
+    "--tab-width": true/false/a number
 }
 ```
 

--- a/linter.py
+++ b/linter.py
@@ -3,6 +3,7 @@ from SublimeLinter.lint import LintMatch, ComposerLinter
 
 
 class Phpcs(ComposerLinter):
+    cmd = ('phpcs', '--report=json', '${args}', '-')
     defaults = {
         'selector': 'embedding.php, source.php  - text.blade',
         # we want auto-substitution of the filename,
@@ -24,13 +25,6 @@ class Phpcs(ComposerLinter):
                     code=error['source'],
                     message=error['message'],
                 )
-
-    def cmd(self):
-        if self.view.settings().get("indentation") == 'tabs':
-            tab_width = self.view.settings().get("tab_size", 4)
-            return ('phpcs', '--report=json', '--tab-width={}'.format(tab_width), '${args}', '-')
-
-        return ('phpcs', '--report=json', '${args}', '-')
 
     def reposition_match(self, line, col, m, vv):
         line_contents = vv.select_line(line)

--- a/linter.py
+++ b/linter.py
@@ -8,7 +8,7 @@ class Phpcs(ComposerLinter):
         # we want auto-substitution of the filename,
         # but `cmd` does not support that yet
         '--stdin-path=': '${file}',
-        "--tab-width": True
+        "--tab-width=": True
     }
     tab_size = 4
 
@@ -27,15 +27,11 @@ class Phpcs(ComposerLinter):
                 )
 
     def cmd(self):
-        tabs2spaces = self.settings.get("--tab-width")
-        if tabs2spaces is True:
-            # autodetect
-            tab_width = self.view.settings().get("tab_size", 4)
-            return ('phpcs', '--report=json', '--tab-width={}'.format(tab_width), '${args}', '-')
-
-        if tabs2spaces is not False:
-            # pass the specific arg
-            return ('phpcs', '--report=json', '--tab-width={}'.format(tabs2spaces), '${args}', '-')
+        self.tab_size = self.view.settings().get("tab_size", 4)
+        if self.settings.get("tab-width") is True:
+            self.settings.set("tab-width", self.tab_size)
+        if self.settings.get("tab-width") is False:
+            self.settings.set("tab-width", 0)
 
         return ('phpcs', '--report=json', '${args}', '-')
 

--- a/linter.py
+++ b/linter.py
@@ -7,8 +7,7 @@ class Phpcs(ComposerLinter):
         'selector': 'embedding.php, source.php  - text.blade',
         # we want auto-substitution of the filename,
         # but `cmd` does not support that yet
-        '--stdin-path=': '${file}',
-        "--tab-width": True
+        '--stdin-path=': '${file}'
     }
     tab_size = 4
 
@@ -27,15 +26,9 @@ class Phpcs(ComposerLinter):
                 )
 
     def cmd(self):
-        tabs2spaces = self.settings.get("--tab-width")
-        if tabs2spaces is True:
-            # autodetect
+        if self.view.settings().get("indentation") == 'tabs':
             tab_width = self.view.settings().get("tab_size", 4)
             return ('phpcs', '--report=json', '--tab-width={}'.format(tab_width), '${args}', '-')
-
-        if tabs2spaces is not False:
-            # pass the specific arg
-            return ('phpcs', '--report=json', '--tab-width={}'.format(tabs2spaces), '${args}', '-')
 
         return ('phpcs', '--report=json', '${args}', '-')
 

--- a/linter.py
+++ b/linter.py
@@ -3,7 +3,6 @@ from SublimeLinter.lint import LintMatch, ComposerLinter
 
 
 class Phpcs(ComposerLinter):
-    cmd = ('phpcs', '--report=json', '${args}', '-')
     defaults = {
         'selector': 'embedding.php, source.php  - text.blade',
         # we want auto-substitution of the filename,
@@ -25,6 +24,13 @@ class Phpcs(ComposerLinter):
                     code=error['source'],
                     message=error['message'],
                 )
+
+    def cmd(self):
+        if self.view.settings().get("indentation") == 'tabs':
+            tab_width = self.view.settings().get("tab_size", 4)
+            return ('phpcs', '--report=json', '--tab-width={}'.format(tab_width), '${args}', '-')
+
+        return ('phpcs', '--report=json', '${args}', '-')
 
     def reposition_match(self, line, col, m, vv):
         line_contents = vv.select_line(line)

--- a/linter.py
+++ b/linter.py
@@ -10,8 +10,10 @@ class Phpcs(ComposerLinter):
         # but `cmd` does not support that yet
         '--stdin-path=': '${file}'
     }
+    tab_size = 4
 
     def find_errors(self, output):
+        self.tab_size = self.view.settings().get("tab_size", 4)
         data = json.loads(output)
         for file_path, file_data in data["files"].items():
             for error in file_data['messages']:
@@ -23,3 +25,9 @@ class Phpcs(ComposerLinter):
                     code=error['source'],
                     message=error['message'],
                 )
+
+    def reposition_match(self, line, col, m, vv):
+        line_contents = vv.select_line(line)
+        tabs_to_spaces = line_contents[:col].count("\t") * (self.tab_size - 1)
+        new_col = max(0, col - tabs_to_spaces)
+        return super().reposition_match(line, new_col, m, vv)

--- a/linter.py
+++ b/linter.py
@@ -8,7 +8,7 @@ class Phpcs(ComposerLinter):
         # we want auto-substitution of the filename,
         # but `cmd` does not support that yet
         '--stdin-path=': '${file}',
-        "--tab-width=": True
+        "--tab-width": True
     }
     tab_size = 4
 
@@ -27,11 +27,15 @@ class Phpcs(ComposerLinter):
                 )
 
     def cmd(self):
-        self.tab_size = self.view.settings().get("tab_size", 4)
-        if self.settings.get("tab-width") is True:
-            self.settings.set("tab-width", self.tab_size)
-        if self.settings.get("tab-width") is False:
-            self.settings.set("tab-width", 0)
+        tabs2spaces = self.settings.get("--tab-width")
+        if tabs2spaces is True:
+            # autodetect
+            tab_width = self.view.settings().get("tab_size", 4)
+            return ('phpcs', '--report=json', '--tab-width={}'.format(tab_width), '${args}', '-')
+
+        if tabs2spaces is not False:
+            # pass the specific arg
+            return ('phpcs', '--report=json', '--tab-width={}'.format(tabs2spaces), '${args}', '-')
 
         return ('phpcs', '--report=json', '${args}', '-')
 

--- a/linter.py
+++ b/linter.py
@@ -7,7 +7,8 @@ class Phpcs(ComposerLinter):
         'selector': 'embedding.php, source.php  - text.blade',
         # we want auto-substitution of the filename,
         # but `cmd` does not support that yet
-        '--stdin-path=': '${file}'
+        '--stdin-path=': '${file}',
+        "--tab-width": True
     }
     tab_size = 4
 
@@ -26,9 +27,15 @@ class Phpcs(ComposerLinter):
                 )
 
     def cmd(self):
-        if self.view.settings().get("indentation") == 'tabs':
+        tabs2spaces = self.settings.get("--tab-width")
+        if tabs2spaces is True:
+            # autodetect
             tab_width = self.view.settings().get("tab_size", 4)
             return ('phpcs', '--report=json', '--tab-width={}'.format(tab_width), '${args}', '-')
+
+        if tabs2spaces is not False:
+            # pass the specific arg
+            return ('phpcs', '--report=json', '--tab-width={}'.format(tabs2spaces), '${args}', '-')
 
         return ('phpcs', '--report=json', '${args}', '-')
 


### PR DESCRIPTION
If your tab width is not 4 it must be specified via args. Otherwise this seems to do the trick. 

I think I've been able to mess it up slightly if you use tabs inside the line (ie. not just as indentation at the beginning of the line) ... but at that point, what the hell are you doing anyway 😅 In this screenshot the squiggles on `$foo` are not well placed, they should be after the `=`. We can only do so much I guess in manipulating the `line_contents[:col]` because we can't recalculate `col` before we use it here.

<img width="687" alt="Screenshot 2025-03-26 at 10 01 47" src="https://github.com/user-attachments/assets/557511ec-ef7a-4815-b969-dc31a1571c8b" />

I think this now also mirrors what you've been seeing with eslint, where the column numbers in the panel no longer line up with what Sublime says is the column in the status bar (in this screenshot the panel says 10, but the status bar says 10+3*(6-1)=25)?

<img width="776" alt="Screenshot 2025-03-26 at 10 03 03" src="https://github.com/user-attachments/assets/86655992-16a1-42a1-af72-b65500401609" />
