### PR TITLE
add -q flag to suppress deprecations

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -3,7 +3,7 @@ from SublimeLinter.lint import LintMatch, PhpLinter
 
 
 class Phpcs(PhpLinter):
-    cmd = ('phpcs', '--report=json', '${args}', '-')
+    cmd = ('phpcs', '-q', '--report=json', '${args}', '-')
     defaults = {
         'selector': 'embedding.php, source.php  - text.blade',
         # we want auto-substitution of the filename,


### PR DESCRIPTION
and progress etc: all stuff we don't need, while keeping the reports we do need. as suggested here: https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/1165#issuecomment-3117808754

```
-q                             Quiet mode; disables progress and verbose output.
```

should fix #59

proof I'm still seeing the same as before:

<img width="594" height="135" alt="Screenshot 2025-07-25 at 15 37 17" src="https://github.com/user-attachments/assets/8b808a0e-25a4-48f8-8548-e84b26da2929" />
